### PR TITLE
chat thread bug

### DIFF
--- a/Chat/ClientApp/src/core/sideEffects.ts
+++ b/Chat/ClientApp/src/core/sideEffects.ts
@@ -140,8 +140,8 @@ const addUserToThread = (displayName: string, emoji: string) => async (dispatch:
   let state: State = getState();
   _displayName = displayName;
   _emoji = emoji;
-  if (state.thread.threadId === undefined) {
-    console.error('Thread Id not created yet');
+  if (!state.thread.threadId) {
+    console.error('No Thread Id'); //but this is ok, for rooms without a thread
     return;
   }
   let threadId: string = state.thread.threadId;


### PR DESCRIPTION
When joining a room with no chat thread id, we were still trying to fetch chat thread info.
The code to check for chat thread id was explicitly checking for "undefined" only, but we had cases where
the id was null. This makes the check check that it exists, and thus stops the bug